### PR TITLE
Fixes for pie chart

### DIFF
--- a/src/pages/deck-stats-colors/deck-stats-colors.html
+++ b/src/pages/deck-stats-colors/deck-stats-colors.html
@@ -24,8 +24,10 @@
           [labels]="colorsChartLabels"
           [legend]="false"
           [chartType]="colorsChartType"
+          [colors]="colorsChartColors"
           (chartHover)="chartHovered($event)"
-          (chartClick)="chartClicked($event)"></canvas>
+          (chartClick)="chartClicked($event)">
+          </canvas>
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/src/pages/deck-stats-colors/deck-stats-colors.ts
+++ b/src/pages/deck-stats-colors/deck-stats-colors.ts
@@ -28,6 +28,15 @@ export class DeckStatsColorsPage {
 	public colorsChartData: number[] = [0, 0, 0, 0, 0, 0];
 	public colorsChartType: string = 'pie';
 	public colorsHover: string = "";
+	public colorsChartColors: any[] = [{
+		backgroundColor: [
+		/* blue*/ "#0000CC",
+		/*black*/"#000000",
+		/*red*/"#CC0000",
+		/*green*/"#008000",
+		/*white*/"#FFFACD",
+		/*other*/"#D3D3D3"]
+	}];
 
 	constructor(
 		public cardService: CardService,

--- a/src/pages/deck-stats-colors/deck-stats-colors.ts
+++ b/src/pages/deck-stats-colors/deck-stats-colors.ts
@@ -66,7 +66,7 @@ export class DeckStatsColorsPage {
 						this.colorsChartData[2]++;
 					} if (card.colors.indexOf('Green') > -1) {
 						this.colorsChartData[3]++;
-					} if (card.colors.indexOf('W') > -1) {
+					} if (card.colors.indexOf('White') > -1) {
 						this.colorsChartData[4]++;
 					}
 				} else {

--- a/src/pages/deck-stats-colors/deck-stats-colors.ts
+++ b/src/pages/deck-stats-colors/deck-stats-colors.ts
@@ -58,15 +58,15 @@ export class DeckStatsColorsPage {
 		for (let card of this.deck.main) {
 			if (!cardService.cardIsTypes(card, [this.land])) {
 				if (card.colorIdentity) {
-					if (card.colorIdentity.indexOf('U') > -1) {
+					if (card.colors.indexOf('Blue') > -1) {
 						this.colorsChartData[0]++;
-					} else if (card.colorIdentity.indexOf('B') > -1) {
+					} if (card.colors.indexOf('Black') > -1) {
 						this.colorsChartData[1]++;
-					} else if (card.colorIdentity.indexOf('R') > -1) {
+					} if (card.colors.indexOf('Red') > -1) {
 						this.colorsChartData[2]++;
-					} else if (card.colorIdentity.indexOf('G') > -1) {
+					} if (card.colors.indexOf('Green') > -1) {
 						this.colorsChartData[3]++;
-					} else if (card.colorIdentity.indexOf('W') > -1) {
+					} if (card.colors.indexOf('W') > -1) {
 						this.colorsChartData[4]++;
 					}
 				} else {


### PR DESCRIPTION
I wasn't sure how to fix the type error on line 71 of deck-stats-cmc.ts, but I just commented it out to get it running. I added some snazzy magic colors to the pie chart, and I also fixed the colors total that's displayed when you hover over part of the chart. It should work correctly for all cards including multicolor and colorless cards.